### PR TITLE
Release 1.2.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,3 +49,13 @@ jobs:
         uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
           dockerfile: ssh/Dockerfile
+
+  prek:
+    name: Prek checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run prek
+        uses: j178/prek-action@v2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,10 @@ Uses `home-assistant/builder/actions` (version pinned to `62a1597`).
 
 Version is read from `ssh/config.yaml` (`version` field). Increment it before publishing.
 
+- **Patch version (x.y.z)**: For minor changes like adding .gitignore, small fixes, or maintenance tasks
+- **Minor version (x.y.0)**: For package updates, dependency updates, or small feature additions
+- **Major version (x.0.0)**: For significant changes, breaking changes, or major feature additions
+
 ## Changelog
 
 Home Assistant requires `CHANGELOG.md` to be in the addon directory (`ssh/`) to detect and display it. Only maintain `ssh/CHANGELOG.md` — do not create a root-level `CHANGELOG.md`.

--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.2
+
+- Add prek GitHub Action for pre-commit hooks in CI workflow
+
 ## 1.2.1
 
 - Add .gitignore to exclude node_modules from version control

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.2.1
+version: 1.2.2
 slug: ssh-fish
 name: Terminal & SSH - Fish edition
 description: Allow logging in remotely to Home Assistant using SSH & Fish shell


### PR DESCRIPTION
## Summary
- Bump version to 1.2.2
- Add prek GitHub Action for pre-commit hooks in CI workflow

## Changes
- Updated ssh/config.yaml version to 1.2.2
- Added entry to ssh/CHANGELOG.md
- Added prek action to .github/workflows/ci.yaml

This PR triggers the release workflow to build and publish version 1.2.2.