### PR TITLE
Release v1.3.1 — Fix AppArmor profile for OpenSSH 10.x

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.1
+
+- Fix AppArmor profile: add sshd-session subprofile for OpenSSH 10.x
+
 ## 1.3.0
 
 - Add AppArmor profile for enhanced container security

--- a/ssh/apparmor.txt
+++ b/ssh/apparmor.txt
@@ -131,5 +131,75 @@ profile ssh-fish flags=(attach_disconnected,mediate_deleted) {
     /dev/** rw,
     /var/empty/** rw,
     /var/log/** rw,
+
+    # OpenSSH 10.x session process
+    /usr/lib/ssh/* cx,
+  }
+
+  profile /usr/lib/ssh/sshd-session flags=(attach_disconnected,mediate_deleted) {
+    #include <abstractions/base>
+    #include <abstractions/nameservice>
+
+    signal receive,
+
+    capability chown,
+    capability dac_override,
+    capability dac_read_search,
+    capability fowner,
+    capability fsetid,
+    capability kill,
+    capability net_bind_service,
+    capability setgid,
+    capability setuid,
+    capability sys_chroot,
+    capability sys_tty_config,
+
+    network inet stream,
+    network inet6 stream,
+
+    /usr/lib/ssh/* rm,
+    /etc/ssh/** rw,
+    /etc/passwd r,
+    /etc/shadow r,
+    /etc/group r,
+    /etc/motd rw,
+    /etc/nsswitch.conf r,
+    /etc/hosts r,
+    /etc/hostname r,
+    /etc/resolv.conf r,
+    /run/** rw,
+    /tmp/** rw,
+    /data/** rw,
+    /proc/** r,
+    /dev/** rw,
+    /var/empty/** rw,
+    /var/log/** rw,
+    /root/** rw,
+    /home/** rw,
+    /config/** rw,
+    /addons/** rw,
+    /addon_configs/** rw,
+    /backup/** r,
+    /media/** rw,
+    /share/** rw,
+    /ssl/** r,
+
+    # Shell & user programs
+    /usr/bin/fish ix,
+    /usr/bin/nvim ix,
+    /usr/bin/tmux ix,
+    /usr/bin/htop ix,
+    /usr/bin/btm ix,
+    /usr/bin/pwgen ix,
+    /usr/bin/mosquitto_pub ix,
+    /usr/bin/mosquitto_sub ix,
+    /usr/bin/git ix,
+    /usr/bin/ha rix,
+    /usr/bin/hassio ix,
+    /usr/bin/ssh-keygen ix,
+    /bin/** ix,
+    /sbin/** ix,
+    /usr/bin/** ix,
+    /usr/sbin/** ix,
   }
 }

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.3.0
+version: 1.3.1
 slug: ssh-fish
 name: Terminal & SSH - Fish edition
 description: Allow logging in remotely to Home Assistant using SSH & Fish shell


### PR DESCRIPTION
## Summary

Bugfix release for the AppArmor profile introduced in v1.3.0.

### Fix

OpenSSH 10.x uses `/usr/lib/ssh/sshd-session` as a separate binary for handling authenticated SSH sessions. The AppArmor profile only had a subprofile for `/usr/sbin/sshd`, which blocked the session binary from executing. This caused SSH connections to fail with:

```
rexec of /usr/lib/ssh/sshd-session failed: Permission denied
```

Added a proper `sshd-session` subprofile that grants access to shells and user programs.