### PR TITLE
Fix Renovate config — restrict APK automerge, add Alpine version tracking

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -37,14 +37,31 @@
       "versioningTemplate": "alpine",
       "datasourceTemplate": "repology",
       "depNameTemplate": "alpine_3_23/{{package}}"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["Dockerfile$"],
+      "matchStrings": [
+        "ARG ALPINE_TAG=(?<currentValue>.+)\\s"
+      ],
+      "datasourceTemplate": "repology",
+      "depNameTemplate": "alpine_3_23/alpine-keys",
+      "versioningTemplate": "alpine"
     }
   ],
   "packageRules": [
     {
       "matchDatasources": ["repology"],
+      "matchUpdateTypes": ["patch"],
       "groupName": "Alpine packages",
       "automerge": true,
       "automergeType": "pr"
+    },
+    {
+      "matchDatasources": ["repology"],
+      "matchUpdateTypes": ["minor", "major"],
+      "groupName": "Alpine packages",
+      "automerge": false
     },
     {
       "matchDatasources": ["docker"],

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -1,4 +1,5 @@
 ARG BUILD_FROM=ghcr.io/hassio-addons/base:20.1.1
+ARG ALPINE_TAG=3_23
 ARG HA_CLI_VERSION="5.1.0"
 FROM $BUILD_FROM
 


### PR DESCRIPTION
## Summary

Two fixes to the Renovate configuration based on best practice review.

### Changes

1. **Restrict Alpine package automerge to patch only** — previously ALL repology updates were automerged (`automerge: true`). Now only patch versions auto-merge; minor/major updates require review. This is safer for a security-sensitive SSH addon.

2. **Add Alpine repo version tracking** — added `ARG ALPINE_TAG=3_23` to the Dockerfile and a Renovate custom manager that tracks `alpine_3_23/alpine-keys`. This makes the Alpine repo version visible on the Renovate dashboard. When the base image bumps to a newer Alpine version, the hardcoded `alpine_3_23/` prefix in the APK manager's `depNameTemplate` needs manual updating — this dependency serves as a canary for that.