### PR TITLE
⬆️ Update to Alpine 3.24

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,7 +36,7 @@
       ],
       "versioningTemplate": "alpine",
       "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_23/{{package}}"
+      "depNameTemplate": "alpine_3_24/{{package}}"
     },
     {
       "customType": "regex",
@@ -45,7 +45,7 @@
         "ARG ALPINE_TAG=(?<currentValue>.+)\\s"
       ],
       "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_23/alpine-keys",
+      "depNameTemplate": "alpine_3_24/alpine-keys",
       "versioningTemplate": "alpine"
     }
   ],

--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.4.0
+
+- Update base image to Alpine 3.24
+- Update packages: git 2.54.0, libuv 1.52.1, mosquitto-clients 2.1.2, openssh 10.3_p1, tmux 3.6b, neovim 0.12.2, fish 4.6.0, htop 3.5.1, bottom 0.12.3
+
 ## 1.3.2
 
 - Remove AppArmor profile (temporarily disabled, causes SSH connection failures)

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -1,22 +1,22 @@
 ARG BUILD_FROM=ghcr.io/hassio-addons/base:21.0.0
-ARG ALPINE_TAG=3_23
+ARG ALPINE_TAG=3_24
 ARG HA_CLI_VERSION="5.2.0"
 FROM $BUILD_FROM
 
 # Setup base
 RUN apk add --no-cache \
-        git=2.52.0-r0 \
-        libuv=1.51.0-r0 \
-        mosquitto-clients=2.0.22-r0 \
-        openssh=10.2_p1-r0 \
+        git=2.54.0-r0 \
+        libuv=1.52.1-r0 \
+        mosquitto-clients=2.1.2-r1 \
+        openssh=10.3_p1-r0 \
         pwgen=2.08-r3 \
-        tmux=3.6-r0 \
+        tmux=3.6b-r0 \
         ttyd=1.7.7-r0 \
-        neovim=0.11.7-r0 \
-        fish=4.0.2-r0 \
-        htop=3.4.1-r1 \
-        bottom=0.10.2-r0 \
-        bottom-fish-completion=0.10.2-r0 \
+        neovim=0.12.2-r0 \
+        fish=4.6.0-r1 \
+        htop=3.5.1-r1 \
+        bottom=0.12.3-r0 \
+        bottom-fish-completion=0.12.3-r0 \
     && ln -sf /usr/bin/nvim /usr/local/bin/vi \
     && ln -sf /usr/bin/nvim /usr/local/bin/vim
 

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.3.2
+version: 1.4.0
 slug: ssh-fish
 name: Terminal & SSH - Fish edition
 description: Allow logging in remotely to Home Assistant using SSH & Fish shell


### PR DESCRIPTION
Updates the addon to Alpine 3.24:

- Bump `ALPINE_TAG` from `3_23` to `3_24`
- Update all pinned packages to Alpine 3.24 versions
- Update renovate.json repology references
- Bump version to 1.4.0

### Package version bumps:
| Package | 3.23 | 3.24 |
|---|---|---|
| git | 2.52.0-r0 | 2.54.0-r0 |
| libuv | 1.51.0-r0 | 1.52.1-r0 |
| mosquitto-clients | 2.0.22-r0 | 2.1.2-r1 |
| openssh | 10.2_p1-r0 | 10.3_p1-r0 |
| tmux | 3.6-r0 | 3.6b-r0 |
| neovim | 0.11.7-r0 | 0.12.2-r0 |
| fish | 4.0.2-r0 | 4.6.0-r1 |
| htop | 3.4.1-r1 | 3.5.1-r1 |
| bottom | 0.10.2-r0 | 0.12.3-r0 |
| bottom-fish-completion | 0.10.2-r0 | 0.12.3-r0 |

Base image (21.0.0) already on Alpine 3.24. HA CLI (5.2.0) unchanged.