### PR TITLE
🐛 Port upstream hardening and documentation improvements (2.1.2)

### DIFF
--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.1.2
+
+- Limit the fish default shell change to the root account only
+- Add `bashio::exit.nok` when setting the SSH account password fails
+- Log security warnings when using the root account or a password for SSH login
+- Document running the `ha` command or Supervisor API non-interactively
+- Document the Web Terminal clipboard copy/paste behavior
+- Add an example to the `packages` option documentation
+- Align the "Preinstalled tools" list in the docs with the actual packages
+
 ## 2.1.1
 
 - Fix web terminal ingress by removing invalid `ingress_port: 0` setting

--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -37,6 +37,18 @@ To copy text from the Web UI:
 To paste text into the Web UI:
 1. Press SHIFT + INSERT.
 
+The Web Terminal is based on xterm.js, which follows X11-style clipboard
+conventions that may differ from what you expect:
+
+- **Copy**: hold `Shift` and select the text with your mouse. The selection is
+  copied to your system clipboard right away (a small scissors icon briefly
+  pops up). There is no need to press `Ctrl+C`.
+- **Paste**: press `Ctrl+Shift+V`, or right-click and choose paste, depending
+  on your browser.
+
+This applies to the Web Terminal in the Home Assistant frontend. A regular SSH
+client uses the clipboard behavior of its own terminal instead.
+
 ### SSH Server Connection
 
 Remote SSH access from the network is disabled by default (See Network below). To connect using an SSH client, such as PuTTY or Linux terminal, you need to supply additional configuration for this app. To enable SSH connectivity, you need to:
@@ -115,6 +127,22 @@ Specifies whether TCP port forwarding (`-L -R` etc.) is permitted. **Note**: Ena
 
 Additional Alpine packages to install in the app container on startup. These are installed every time the app starts. If installation fails, a warning is logged but the app continues.
 
+The packages are installed using Alpine's package manager, so any package name
+from the [Alpine package index][alpine-packages] works. List the package names
+exactly as they appear there. For example:
+
+```yaml
+packages:
+  - iperf3
+  - socat
+  - joe
+```
+
+This installs the packages on every start, so they are always available when
+you log in. Note that package names are not always the same as the command
+they provide (for example, the `ncat` command comes from the `nmap-ncat`
+package).
+
 ### Option: `init_commands`
 
 Shell commands to execute on app startup, after everything is configured. Useful for custom setup tasks. Example:
@@ -133,12 +161,45 @@ Remote SSH access can be disabled again, by clearing the input box, saving the c
 
 ## Preinstalled tools
 
-- **Shell**: fish (with neovim as vi/vim alternative)
+- **Shell**: fish (with neovim as vi/vim/neovim alternative)
 - **Terminal**: tmux, screen
-- **System**: htop, bottom, ncdu, procps-ng
-- **Network**: tcpdump, mtr, nmap-ncat, mosquitto-clients, bind-tools
+- **System**: htop, bottom, ncdu
+- **Network**: tcpdump, mtr, nmap-ncat, mosquitto-clients
 - **File**: rsync, wget, git
-- **Disk**: lsblk
+
+Want a tool that is not listed? Install it permanently by adding the package
+to the `packages` option, or temporarily with the `apk` command.
+
+## Running the `ha` command or Supervisor API non-interactively
+
+When you log in interactively, the app starts a login shell that sets up the
+`SUPERVISOR_TOKEN` environment variable. The `ha` command and the Supervisor
+API need that token, so commands like `ha core info` just work.
+
+Running a command non-interactively does **not** start a login shell, so the
+token is not set and the command fails with a `401` error. For example, this
+fails:
+
+```shell
+ssh your-instance "ha core info"
+```
+
+Wrap the command in a login shell so the environment, and with it the token,
+is loaded:
+
+```shell
+ssh your-instance 'fish -lc "ha core info"'
+```
+
+Or, if you prefer bash:
+
+```shell
+ssh your-instance 'bash -lc "ha core info"'
+```
+
+The same applies when calling the Supervisor API directly or running commands
+from automations: invoke them through a login shell (`fish -lc '...'`) so the
+`SUPERVISOR_TOKEN` is available.
 
 ## Known issues and limitations
 
@@ -153,6 +214,7 @@ Apache License 2.0
 
 In case you've found a bug, please [open an issue on our GitHub][issue].
 
+[alpine-packages]: https://pkgs.alpinelinux.org/packages
 [discord]: https://www.home-assistant.io/join-chat
 [forum]: https://community.home-assistant.io
 [issue]: https://github.com/computeralex92/ha-ssh-fish/issues

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -28,8 +28,8 @@ RUN apk add --no-cache \
     && ln -sf /usr/bin/nvim /usr/local/bin/vim \
     && ln -sf /usr/bin/nvim /usr/local/bin/neovim
 
-# Use fish as default shell
-RUN sed -i "s|/bin/sh|/usr/bin/fish|" /etc/passwd
+# Use fish as default shell (root only)
+RUN sed -i -r -e 's|^(root:.*)/bin/sh$|\1/usr/bin/fish|' /etc/passwd
 
 # Home Assistant CLI
 ARG BUILD_ARCH

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.1.1
+version: 2.1.2
 slug: ssh-fish
 name: Terminal & SSH - Fish edition
 description: Allow logging in remotely to Home Assistant using SSH & Fish shell

--- a/ssh/rootfs/etc/cont-init.d/ssh.sh
+++ b/ssh/rootfs/etc/cont-init.d/ssh.sh
@@ -71,6 +71,16 @@ if bashio::config.true 'ssh.compatibility_mode'; then
     sed -i '/^KexAlgorithms /s/^/#/' /etc/ssh/sshd_config
 fi
 
+# Warn about using the root user
+bashio::log.warning 'Logging in with "root" as the username, is security wise a bad idea!'
+bashio::log.warning 'Most attacks against SSH are attempts to login using the "root" username.'
+
+# Warn about using a password
+if bashio::var.has_value "${PASSWORD}"; then
+    bashio::log.warning 'Logging in with a SSH password is security wise, a bad idea!'
+    bashio::log.warning 'Please, consider using a public/private key pair.'
+fi
+
 # Setup authentication
 if bashio::var.has_value "${AUTHORIZED_KEYS}"; then
     bashio::log.info "Setup authorized_keys"
@@ -80,11 +90,13 @@ if bashio::var.has_value "${AUTHORIZED_KEYS}"; then
 
     # Unlock account with random password
     NEWPASSWORD="$(pwgen -s 64 1)"
-    echo "root:${NEWPASSWORD}" | chpasswd 2>/dev/null
+    echo "root:${NEWPASSWORD}" | chpasswd 2> /dev/null \
+        || bashio::exit.nok 'Failed setting the password for the user account'
 elif bashio::var.has_value "${PASSWORD}"; then
     bashio::log.info "Setup password login"
 
-    echo "root:${PASSWORD}" | chpasswd 2>/dev/null
+    echo "root:${PASSWORD}" | chpasswd 2> /dev/null \
+        || bashio::exit.nok 'Failed setting the password for the user account'
 else
     bashio::log.warning "No SSH credentials configured!"
     bashio::log.warning "Set ssh.authorized_keys or ssh.password to enable SSH login."


### PR DESCRIPTION
Syncs improvements from upstream, adapted for the fish-shell fork.

- Dockerfile: limit fish default-shell change to root account only
- ssh.sh: exit.nok on password failure + security warnings
- DOCS.md: ha non-interactive, clipboard, packages example, accurate tool list
- config.yaml/CHANGELOG.md: bump to 2.1.2