### PR TITLE
🔖 Port upstream improvements (v2.3.0)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,12 @@
   "labels": ["dependencies", "no-stale"],
   "commitMessagePrefix": "⬆️",
   "commitMessageTopic": "{{depName}}",
+  "customDatasources": {
+    "alpine": {
+      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/v3.24/main/x86_64/",
+      "format": "html"
+    }
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -35,8 +41,9 @@
         "\\s\\s(?<package>[a-z0-9][a-z0-9-_]+)=(?<currentValue>[a-z0-9-_.]+)\\s+"
       ],
       "versioningTemplate": "loose",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_24/{{package}}"
+      "datasourceTemplate": "custom.alpine",
+      "depNameTemplate": "alpine_3_24/{{package}}",
+      "extractVersionTemplate": "^{{{package}}}-(?<version>\\d.*)\\.apk$"
     }
   ],
   "packageRules": [
@@ -46,8 +53,22 @@
       "automerge": true
     },
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true
+    },
+    {
+      "description": "Packages that live in the Alpine community repository",
+      "matchDatasources": ["custom.alpine"],
+      "matchPackageNames": [
+        "alpine_3_24/bottom",
+        "alpine_3_24/bottom-fish-completion",
+        "alpine_3_24/mtr",
+        "alpine_3_24/neovim",
+        "alpine_3_24/ttyd"
+      ],
+      "registryUrls": [
+        "https://dl-cdn.alpinelinux.org/alpine/v3.24/community/x86_64/"
+      ]
     },
     {
       "groupName": "App base image",
@@ -61,19 +82,19 @@
     },
     {
       "groupName": "Docker",
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true,
       "matchPackageNames": ["/^alpine_.*/docker.*$/"]
     },
     {
       "groupName": "OpenSSL",
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true,
       "matchPackageNames": ["/^alpine_.*/openssl.*$/"]
     },
     {
       "groupName": "Python",
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["custom.alpine"],
       "automerge": true,
       "matchPackageNames": ["/^alpine_.*/python3(-dev)?$/"]
     }

--- a/ssh/CHANGELOG.md
+++ b/ssh/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.3.0
+
+- Persist `~/.gitconfig` and `~/.vscode-server` across restarts
+- Fix Renovate Alpine package updates by replacing Repology with the Alpine CDN datasource
+
 ## 2.2.0
 
 - Update base image to v21.0.3

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 2.2.0
+version: 2.3.0
 slug: ssh-fish
 name: Terminal & SSH - Fish edition
 description: Allow logging in remotely to Home Assistant using SSH & Fish shell

--- a/ssh/rootfs/etc/cont-init.d/profile.sh
+++ b/ssh/rootfs/etc/cont-init.d/profile.sh
@@ -17,6 +17,18 @@ if ! bashio::fs.file_exists /data/.fish_config; then
 fi
 chmod 600 /data/.fish_config
 
+# Persist git config
+if ! bashio::fs.file_exists /data/.gitconfig; then
+    touch /data/.gitconfig
+fi
+ln -sf /data/.gitconfig "${HOME}/.gitconfig"
+
+# Persist VS Code server state
+if ! bashio::fs.directory_exists /data/.vscode-server; then
+    mkdir -p /data/.vscode-server
+fi
+ln -sf /data/.vscode-server "${HOME}/.vscode-server"
+
 # Make Home Assistant TOKEN available on the CLI
 mkdir -p /etc/profile.d
 echo "export SUPERVISOR_TOKEN=\"${SUPERVISOR_TOKEN}\"" \


### PR DESCRIPTION
Ported upstream improvements onto a branch:

- Persist ~/.gitconfig (symlinked to /data/.gitconfig)
- Persist ~/.vscode-server (symlinked to /data/.vscode-server)
- Fix Renovate Alpine pin updates (upstream PR #1119) - replace Repology with Alpine CDN datasource; community rules adapted to this fork's packages

Version bumped to 2.3.0 with changelog. Shellcheck passes.